### PR TITLE
Fixed issue #6 where Py3 would generate a bytes object from b64encode

### DIFF
--- a/certbot_external_auth/plugin.py
+++ b/certbot_external_auth/plugin.py
@@ -460,10 +460,20 @@ s.serve_forever()" """
         json_data[FIELD_CMD] = COMMAND_PERFORM
         json_data[FIELD_TYPE] = achall.chall.typ
         json_data[FIELD_DOMAIN] = achall.domain
-        json_data[FIELD_TOKEN] = b64.b64encode(achall.chall.token)
+        json_data[FIELD_TOKEN] = b64.b64encode(achall.chall.token) # Py3 - This becomes a bytes obj. JSON can't decode that.
         json_data[FIELD_VALIDATION] = validation
         json_data[FIELD_TXT_DOMAIN] = achall.validation_domain_name(achall.domain)
         json_data[FIELD_KEY_AUTH] = response.key_authorization
+        for key, val in list(json_data.items()):
+            # Not highly effecient, would be neater to clean up FIELD_TOKEN.
+            # But if any of the others turn to bytes in the future, this will solve it:
+            if type(key) == bytes:
+                del json_data[key]
+                key = key.decode('UTF-8')
+                json_data[key] = val
+
+            if type(val) == bytes:
+                json_data[key] = val.decode('UTF-8')
 
         if not self.conf("test-mode"):
             if self._is_text_mode():

--- a/certbot_external_auth/plugin.py
+++ b/certbot_external_auth/plugin.py
@@ -15,6 +15,7 @@ import types
 import calendar
 import collections
 from collections import OrderedDict
+from builtins import bytes
 import atexit
 from six.moves import queue  # pylint: disable=import-error
 
@@ -464,16 +465,8 @@ s.serve_forever()" """
         json_data[FIELD_VALIDATION] = validation
         json_data[FIELD_TXT_DOMAIN] = achall.validation_domain_name(achall.domain)
         json_data[FIELD_KEY_AUTH] = response.key_authorization
-        for key, val in list(json_data.items()):
-            # Not highly effecient, would be neater to clean up FIELD_TOKEN.
-            # But if any of the others turn to bytes in the future, this will solve it:
-            if type(key) == bytes:
-                del json_data[key]
-                key = key.decode('UTF-8')
-                json_data[key] = val
 
-            if type(val) == bytes:
-                json_data[key] = val.decode('UTF-8')
+        json_data = self._json_sanitize_dict(json_data)
 
         if not self.conf("test-mode"):
             if self._is_text_mode():
@@ -733,6 +726,26 @@ s.serve_forever()" """
     #
     # Helper methods & UI
     #
+
+    def _json_sanitize_dict(self, dictionary):
+        for key, val in list(dictionary.items()):
+            # Not highly effecient, would be neater to clean up FIELD_TOKEN.
+            # But if any of the others turn to bytes in the future, this will solve it:
+            if type(key) == bytes:
+                del dictionary[key]
+                key = key.decode('UTF-8')
+                dictionary[key] = val
+
+            if type(val) == bytes:
+                dictionary[key] = val.decode('UTF-8')
+            elif type(val) in (list, tuple):
+                nval = []
+                for item in val:
+                    if type(item) == bytes:
+                        item = item.decode('UTF-8')
+                    nval.append(item)
+                dictionary[key] = nval
+        return dictionary
 
     def _is_file_executable(self, fpath):
         if os.name.lower() == 'posix':


### PR DESCRIPTION
A more suitable solution would be https://stackoverflow.com/a/25829327/929999

However, since I don't know where you'd want to put that in (at the start of the function calls or at the end for instance). I'll leave this temporary solution here for now.